### PR TITLE
fix: result folder is generated too many times

### DIFF
--- a/celery_tasks/yolo.py
+++ b/celery_tasks/yolo.py
@@ -12,7 +12,7 @@ class YoloModel:
         try:
             with torch.no_grad():
                 result = self.model(img)
-            result.save('api/static/results/')
+            result.save(save_dir='api/static/results/', exist_ok=True)
             final_result = {}
             data = []
             file_name = f'static/{result.files[0]}'


### PR DESCRIPTION
Result folder should be generated only one time and use the original one as save folder.